### PR TITLE
MDlib: change UpdateStates interface to standard used elsewhere

### DIFF
--- a/src/moordyn.jl
+++ b/src/moordyn.jl
@@ -82,10 +82,10 @@ function mdInit(;mdLib_filename="$path/../deps/bin/MoorDyn_c_lib_x64.dll", input
 
     global mdLib = Libdl.dlopen(mdLib_filename) # Open the library explicitly.
     global mdActive = true
-    global symInit = Libdl.dlsym(mdLib, :MD_INIT_C)   # Get a symbol for the function to call.
-    global symCalcOutput = Libdl.dlsym(mdLib, :MD_CALCOUTPUT_C)
-    global symUpdateStates = Libdl.dlsym(mdLib, :MD_UPDATESTATES_C)
-    global symEnd = Libdl.dlsym(mdLib, :MD_END_C)
+    global symInit = Libdl.dlsym(mdLib, :MD_C_Init)   # Get a symbol for the function to call.
+    global symCalcOutput = Libdl.dlsym(mdLib, :MD_C_CalcOutput)
+    global symUpdateStates = Libdl.dlsym(mdLib, :MD_C_UpdateStates)
+    global symEnd = Libdl.dlsym(mdLib, :MD_C_End)
     global mdErr = MDError([0], string(repeat(" ", 1025)))
 
     ccall(symInit,Cint,


### PR DESCRIPTION
This change removes the first variable that is passed to UpdateStates.  This variable, T-dt is not necessary as it is tracked within the library. Other interfaces to OpenFAST libraries do not have this variable in the interface, so this trues up the MD interface to match those.

This goes with recent changes to the MoorDyn_c_binding library on the OpenFAST repository (to be posted later today).