### PR TITLE
Add OpenFAST wrapper verification tests

### DIFF
--- a/test/pure_helpers_unit.jl
+++ b/test/pure_helpers_unit.jl
@@ -106,6 +106,206 @@ end
     @test_throws ArgumentError OWENSOpenFASTWrappers.openfastInputString(1; source=:text)
 end
 
+@testset "native wrapper failure guards and error-state resets" begin
+    Core.eval(OWENSOpenFASTWrappers, :(adi_active = false))
+    Core.eval(OWENSOpenFASTWrappers, :(hd_active = false))
+    Core.eval(OWENSOpenFASTWrappers, :(ifw_active = false))
+    Core.eval(OWENSOpenFASTWrappers, :(md_active = false))
+
+    Core.eval(OWENSOpenFASTWrappers, :(backup_Vx = 11.25))
+    Core.eval(OWENSOpenFASTWrappers, :(ifw_err = IFW_Error([0], "inflow-ok")))
+    @test OWENSOpenFASTWrappers.ifwcalcoutput([0.0, 1.0, 2.0], 3.0) ==
+          [11.25, 0.0, 0.0]
+    OWENSOpenFASTWrappers.ifwend()
+
+    @test_throws ErrorException OWENSOpenFASTWrappers.HD_CalcOutput(
+        0.0,
+        zeros(6),
+        zeros(6),
+        zeros(6),
+        zeros(Float32, 6),
+        zeros(Float32, 1),
+    )
+    @test_throws ErrorException OWENSOpenFASTWrappers.HD_UpdateStates(
+        0.0,
+        0.1,
+        zeros(6),
+        zeros(6),
+        zeros(6),
+    )
+    @test_throws ErrorException OWENSOpenFASTWrappers.MD_CalcOutput(
+        0.0,
+        zeros(6),
+        zeros(6),
+        zeros(6),
+        zeros(Float32, 6),
+        zeros(Float32, 1),
+    )
+    @test_throws ErrorException OWENSOpenFASTWrappers.MD_UpdateStates(
+        0.0,
+        0.1,
+        zeros(6),
+        zeros(6),
+        zeros(6),
+    )
+    OWENSOpenFASTWrappers.HD_End()
+    OWENSOpenFASTWrappers.MD_End()
+    OWENSOpenFASTWrappers.endAll()
+
+    @test_throws ErrorException OWENSOpenFASTWrappers.adiSetRotorMotion(
+        1,
+        zeros(3),
+        zeros(9),
+        zeros(6),
+        zeros(6),
+        zeros(3),
+        zeros(9),
+        zeros(6),
+        zeros(6),
+        zeros(3, 1),
+        zeros(9, 1),
+        zeros(6, 1),
+        zeros(6, 1),
+        1,
+        zeros(3, 1),
+        zeros(9, 1),
+        zeros(6, 1),
+        zeros(6, 1),
+    )
+    @test_throws ErrorException OWENSOpenFASTWrappers.adiCalcOutput(0.0, 3)
+    Core.eval(OWENSOpenFASTWrappers, :(turbine = [Turbine(1.0, [0.0], zeros(3), 1, 1, 1, [1 1], [1 1], nothing, nothing, true)]))
+    @test_throws ErrorException OWENSOpenFASTWrappers.adiGetRotorLoads(1)
+    @test_throws ErrorException OWENSOpenFASTWrappers.adiUpdateStates(0.0, 0.1)
+    @test_throws ErrorException OWENSOpenFASTWrappers.setRotorMotion(1)
+
+    Core.eval(OWENSOpenFASTWrappers, :(hd_abort_error_level = 4))
+    Core.eval(OWENSOpenFASTWrappers, :(hd_err = HD_Error([0], "hydro-ok")))
+    OWENSOpenFASTWrappers.hd_check_error()
+    @test OWENSOpenFASTWrappers.hd_err.error_status == [0]
+    @test length(OWENSOpenFASTWrappers.hd_err.error_message) == 1025
+
+    Core.eval(OWENSOpenFASTWrappers, :(hd_err = HD_Error([2], "hydro-warning")))
+    @test_logs (:warn, r"Error status 2: hydro-warning") OWENSOpenFASTWrappers.hd_check_error()
+    @test OWENSOpenFASTWrappers.hd_err.error_status == [0]
+
+    hydro_fatal = Ref{Any}(nothing)
+    Core.eval(OWENSOpenFASTWrappers, :(hd_err = HD_Error([4], "hydro-fatal")))
+    @test_logs (:warn, r"Error status 4: hydro-fatal") begin
+        hydro_fatal[] = try
+            OWENSOpenFASTWrappers.hd_check_error()
+            nothing
+        catch err
+            err
+        end
+    end
+    @test hydro_fatal[] isa ErrorException
+    @test occursin("HydroDyn terminated prematurely", sprint(showerror, hydro_fatal[]))
+
+    Core.eval(OWENSOpenFASTWrappers, :(ifw_abort_error_level = 4))
+    Core.eval(OWENSOpenFASTWrappers, :(ifw_err = IFW_Error([0], "inflow-ok")))
+    OWENSOpenFASTWrappers.ifw_check_error()
+    @test OWENSOpenFASTWrappers.ifw_err.error_status == [0]
+    @test length(OWENSOpenFASTWrappers.ifw_err.error_message) == 1025
+
+    Core.eval(OWENSOpenFASTWrappers, :(ifw_err = IFW_Error([2], "inflow-warning")))
+    @test_logs (:warn, r"Error status 2: inflow-warning") OWENSOpenFASTWrappers.ifw_check_error()
+    @test OWENSOpenFASTWrappers.ifw_err.error_status == [0]
+
+    inflow_fatal = Ref{Any}(nothing)
+    Core.eval(OWENSOpenFASTWrappers, :(ifw_err = IFW_Error([4], "inflow-fatal")))
+    @test_logs (:warn, r"Error status 4: inflow-fatal") begin
+        inflow_fatal[] = try
+            OWENSOpenFASTWrappers.ifw_check_error()
+            nothing
+        catch err
+            err
+        end
+    end
+    @test inflow_fatal[] isa ErrorException
+    @test occursin("InflowWind terminated prematurely", sprint(showerror, inflow_fatal[]))
+
+    Core.eval(OWENSOpenFASTWrappers, :(md_abort_error_level = 4))
+    Core.eval(OWENSOpenFASTWrappers, :(md_err = MD_Error([0], "moor-ok")))
+    OWENSOpenFASTWrappers.md_check_error()
+    @test OWENSOpenFASTWrappers.md_err.error_status == [0]
+    @test length(OWENSOpenFASTWrappers.md_err.error_message) == 1025
+
+    Core.eval(OWENSOpenFASTWrappers, :(md_err = MD_Error([2], "moor-warning")))
+    @test_logs (:warn, r"Error status 2: moor-warning") OWENSOpenFASTWrappers.md_check_error()
+    @test OWENSOpenFASTWrappers.md_err.error_status == [0]
+
+    moor_fatal = Ref{Any}(nothing)
+    Core.eval(OWENSOpenFASTWrappers, :(md_err = MD_Error([4], "moor-fatal")))
+    @test_logs (:warn, r"Error status 4: moor-fatal") begin
+        moor_fatal[] = try
+            OWENSOpenFASTWrappers.md_check_error()
+            nothing
+        catch err
+            err
+        end
+    end
+    @test moor_fatal[] isa ErrorException
+    @test occursin("MoorDyn terminated prematurely", sprint(showerror, moor_fatal[]))
+
+    Core.eval(OWENSOpenFASTWrappers, :(adi_abort_error_level = 4))
+    Core.eval(OWENSOpenFASTWrappers, :(adi_err = adiError([0], "aero-ok")))
+    OWENSOpenFASTWrappers.adi_check_error()
+    @test OWENSOpenFASTWrappers.adi_err.error_status == [0]
+    @test length(OWENSOpenFASTWrappers.adi_err.error_message) == 1025
+
+    Core.eval(OWENSOpenFASTWrappers, :(adi_err = adiError([2], "aero-warning")))
+    @test_logs (:warn, r"Error status 2: aero-warning") OWENSOpenFASTWrappers.adi_check_error()
+    @test OWENSOpenFASTWrappers.adi_err.error_status == [0]
+
+    aero_fatal = Ref{Any}(nothing)
+    Core.eval(OWENSOpenFASTWrappers, :(adi_err = adiError([4], "aero-fatal")))
+    @test_logs (:error, r"Error status 4: aero-fatal") begin
+        aero_fatal[] = try
+            OWENSOpenFASTWrappers.adi_check_error()
+            nothing
+        catch err
+            err
+        end
+    end
+    @test aero_fatal[] isa ErrorException
+    @test occursin("AeroDyn-Inflow terminated prematurely", sprint(showerror, aero_fatal[]))
+
+    mktempdir() do dir
+        hydro_file = joinpath(dir, "hydrodyn.dat")
+        write(hydro_file, "header\nline\n")
+        @test_throws SystemError OWENSOpenFASTWrappers.HD_Init(
+            output_root_name=joinpath(dir, "HD"),
+            hd_input_file=hydro_file,
+            ss_input_file=joinpath(dir, "missing_seastate.dat"),
+        )
+
+        hydro_direct_error = Ref{Any}(nothing)
+        @test_logs (:error, r"Hydrodyn file") (:error, r"Hydrodyn file") begin
+            hydro_direct_error[] = try
+                OWENSOpenFASTWrappers.HD_Init(output_root_name=joinpath(dir, "HD-direct"))
+                nothing
+            catch err
+                err
+            end
+        end
+        @test hydro_direct_error[] isa UndefVarError
+
+        uniform_file = joinpath(dir, "uniform.wnd")
+        write(uniform_file, "! header\n\n")
+        @test_throws BoundsError OWENSOpenFASTWrappers.ifwinit(
+            turbsim_filename=uniform_file,
+        )
+        @test_throws BoundsError OWENSOpenFASTWrappers.ifwinit(
+            inflowlib_filename=nothing,
+            turbsim_filename=uniform_file,
+        )
+
+        @test_throws SystemError OWENSOpenFASTWrappers.MD_Init(
+            md_input_file=joinpath(dir, "missing_moordyn.dat"),
+        )
+    end
+end
+
 @testset "pure input-file writers" begin
     mktempdir() do dir
         blade_file = joinpath(dir, "blade.dat")
@@ -134,6 +334,34 @@ end
         @test occursin("\"$spaced_blade_file\" ADBlFile(1)", ad_input_text)
         @test occursin("\"$spaced_airfoil_file\"    AFNames", ad_input_text)
         @test occursin("\"$spaced_olaf_file\" OLAFInputFileName", ad_input_text)
+
+        @test OWENSOpenFASTWrappers.quotedOpenFASTString("plain.dat", "unit") ==
+              "\"plain.dat\""
+        quote_error = try
+            OWENSOpenFASTWrappers.quotedOpenFASTString("bad\"name.dat", "unit filename")
+            nothing
+        catch err
+            err
+        end
+        @test quote_error isa ArgumentError
+        @test occursin(
+            "unit filename cannot contain double quotes: bad\"name.dat",
+            sprint(showerror, quote_error),
+        )
+
+        single_airfoil_file = joinpath(dir, "single airfoil.dat")
+        two_blade_input_file = joinpath(dir, "AD two blades.dat")
+        two_blade_text = OWENSOpenFASTWrappers.writeADinputFile(
+            two_blade_input_file,
+            [spaced_blade_file, "second blade.dat"],
+            single_airfoil_file,
+            spaced_olaf_file,
+        )
+        @test read(two_blade_input_file, String) == two_blade_text
+        @test occursin("1                      NumAFfiles", two_blade_text)
+        @test occursin("\"$single_airfoil_file\"    AFNames", two_blade_text)
+        @test occursin("\"$spaced_blade_file\" ADBlFile(1)", two_blade_text)
+        @test occursin("\"second blade.dat\" ADBlFile(2)", two_blade_text)
 
         olaf_file = joinpath(dir, "OLAF.dat")
         olaf_text = OWENSOpenFASTWrappers.writeOLAFfile(olaf_file; nNWPanel=11, nFWPanels=4)

--- a/test/root_motion_unit.jl
+++ b/test/root_motion_unit.jl
@@ -1,4 +1,5 @@
 using OWENSOpenFASTWrappers
+using LinearAlgebra: I
 
 @testset "root hub rotation kinematics" begin
     turbine = OWENSOpenFASTWrappers.Turbine(
@@ -76,4 +77,224 @@ end
     @test size(root_acc) == (6, 1)
     @test root_vel[:, 1] == Float32[0.0, 0.0, 2.0, 2.0, 0.0, 0.0]
     @test root_acc[:, 1] == Float32[0.0, 0.0, 3.0, 3.0, 0.0, 0.0]
+end
+
+@testset "HAWT mesh position, velocity, and orientation kinematics" begin
+    mesh = (
+        x = [1.0, 2.0, 3.0, 4.0],
+        y = [10.0, 20.0, 30.0, 40.0],
+        z = [100.0, 200.0, 300.0, 400.0],
+    )
+    ort = (
+        Psi_d = zeros(4),
+        Theta_d = zeros(4),
+        Twist_d = zeros(4),
+    )
+    blade_idx = [1 2; 4 3]
+    turbine = OWENSOpenFASTWrappers.Turbine(
+        50.0,
+        [2.0],
+        zeros(3),
+        1,
+        2,
+        4,
+        blade_idx,
+        blade_idx,
+        mesh,
+        ort,
+        true,
+    )
+
+    u_j = zeros(24)
+    udot_j = zeros(24)
+    uddot_j = zeros(24)
+    for inode in 1:4
+        offset = (inode - 1) * 6
+        u_j[offset+1:offset+3] = [0.1inode, 0.2inode, -0.3inode]
+        udot_j[offset+1:offset+6] = [inode, 10inode, 100inode, 0.1inode, 0.2inode, 0.3inode]
+        uddot_j[offset+1:offset+6] = [-inode, -10inode, -100inode, -0.1inode, -0.2inode, -0.3inode]
+    end
+
+    nac_pos = [5.0, -2.0, 1.0]
+    hub_pos = zeros(3)
+    hub_angle = zeros(3)
+
+    root_pos = OWENSOpenFASTWrappers.getRootPos(
+        turbine,
+        u_j,
+        0.0,
+        nac_pos,
+        hub_pos,
+        hub_angle,
+    )
+    @test root_pos isa Matrix{Float32}
+    @test root_pos ≈ Float32[
+        6.1 9.4
+        8.2 38.8
+        100.7 399.8
+    ] atol = 1f-5
+
+    mesh_pos = OWENSOpenFASTWrappers.getAD15MeshPos(
+        turbine,
+        u_j,
+        0.0,
+        nac_pos,
+        hub_pos,
+        hub_angle,
+    )
+    @test mesh_pos isa Matrix{Float32}
+    @test mesh_pos ≈ Float32[
+        104.7 204.4 403.8 304.1
+        8.2 18.4 38.8 28.6
+        -0.1 -1.2 -3.4 -2.3
+    ] atol = 1f-5
+
+    blade_mesh_pos = Float32[
+        0.0 0.0 0.0 0.0
+        1.0 2.0 4.0 3.0
+        0.0 0.0 -1.0 1.0
+    ]
+    hub_vel = [0.5, -0.25, 1.0, 9.0, 9.0, 9.0]
+    hub_acc = [-0.5, 0.25, -1.0, 8.0, 8.0, 8.0]
+    mesh_vel, mesh_acc = OWENSOpenFASTWrappers.getAD15MeshVelAcc(
+        turbine,
+        blade_mesh_pos,
+        udot_j,
+        uddot_j,
+        0.0,
+        2.0,
+        3.0,
+        zeros(3),
+        hub_pos,
+        hub_angle,
+        hub_vel,
+        hub_acc,
+    )
+    @test mesh_vel isa Matrix{Float32}
+    @test mesh_acc isa Matrix{Float32}
+    @test mesh_vel ≈ Float32[
+        1.5 2.5 4.5 3.5
+        9.75 19.75 41.75 27.75
+        103.0 205.0 409.0 307.0
+        2.1 2.2 2.4 2.3
+        0.2 0.4 0.8 0.6
+        0.3 0.6 1.2 0.9
+    ] atol = 1f-6
+    @test mesh_acc ≈ Float32[
+        -1.5 -2.5 -4.5 -3.5
+        -9.75 -19.75 -36.75 -32.75
+        -98.0 -195.0 -389.0 -292.0
+        2.9 2.8 2.6 2.7
+        -0.2 -0.4 -0.8 -0.6
+        -0.3 -0.6 -1.2 -0.9
+    ] atol = 1f-6
+
+    expected_hawt_dcm = Float32[
+        -1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        -1.0,
+    ]
+    root_dcm = OWENSOpenFASTWrappers.getRootDCM(turbine, u_j, 0.0, hub_angle)
+    @test root_dcm isa Matrix
+    @test root_dcm ≈ repeat(expected_hawt_dcm, 1, 2) atol = 1f-6
+
+    dcm_turbine = OWENSOpenFASTWrappers.Turbine(
+        50.0,
+        [2.0],
+        zeros(3),
+        1,
+        2,
+        6,
+        blade_idx,
+        blade_idx,
+        mesh,
+        ort,
+        true,
+    )
+    mesh_dcm = OWENSOpenFASTWrappers.getAD15MeshDCM(dcm_turbine, u_j, 0.0, hub_angle)
+    @test mesh_dcm isa Matrix
+    @test mesh_dcm ≈ repeat(expected_hawt_dcm, 1, 6) atol = 1f-6
+end
+
+@testset "deformAD15 updates HAWT motion state before inactive-library guard" begin
+    mesh = (
+        x = [0.0, 0.0, 0.0],
+        y = [1.0, 2.0, 3.0],
+        z = [0.0, 0.0, 0.0],
+        numNodes = 3,
+    )
+    ort = (
+        Psi_d = zeros(3),
+        Theta_d = zeros(3),
+        Twist_d = zeros(3),
+    )
+    turbine = OWENSOpenFASTWrappers.Turbine(
+        2.0,
+        [0.0],
+        zeros(3),
+        1,
+        1,
+        3,
+        [1 3],
+        [1 2],
+        mesh,
+        ort,
+        true,
+    )
+    structure = OWENSOpenFASTWrappers.Structure(
+        zeros(Float32, 3),
+        vec(Matrix{Float64}(I, 3, 3)),
+        zeros(Float32, 6),
+        zeros(Float32, 6),
+        zeros(Float32, 3),
+        Matrix{Float64}(I, 3, 3),
+        zeros(Float32, 6),
+        zeros(Float32, 6),
+        zeros(Float32, 3, 1),
+        zeros(9, 1),
+        zeros(Float32, 6, 1),
+        zeros(Float32, 6, 1),
+        zeros(Float32, 3, 3),
+        zeros(9, 3),
+        zeros(Float32, 6, 3),
+        zeros(Float32, 6, 3),
+    )
+    Core.eval(OWENSOpenFASTWrappers, :(adi_active = false))
+    Core.eval(OWENSOpenFASTWrappers, :(turbine = [$turbine]))
+    Core.eval(OWENSOpenFASTWrappers, :(turbstruct = [$structure]))
+
+    hub_vel = [zeros(Float32, 6)]
+    hub_acc = [zeros(Float32, 6)]
+    deform_error = try
+        OWENSOpenFASTWrappers.deformAD15(
+            [zeros(18)],
+            [zeros(18)],
+            [zeros(18)],
+            [0.0],
+            [7.0],
+            [0.7],
+            [zeros(Float32, 3)],
+            [zeros(3)],
+            hub_vel,
+            hub_acc,
+        )
+        nothing
+    catch err
+        err
+    end
+    @test deform_error isa ErrorException
+    @test occursin("Could not set rotor motion turbine 1", sprint(showerror, deform_error))
+    @test hub_vel[1] == Float32[0.0, 0.0, 0.0, 7.0, 0.0, 0.0]
+    @test hub_acc[1] == Float32[0.0, 0.0, 0.0, 0.7, 0.0, 0.0]
+    @test OWENSOpenFASTWrappers.turbstruct[1].rootPos ≈ Float32[0.0; 1.0; 0.0;;] atol = 1f-6
+    @test OWENSOpenFASTWrappers.turbstruct[1].rootVel[:, 1] ≈
+          Float32[0.0, 0.0, 7.0, 7.0, 0.0, 0.0] atol = 1f-6
+    @test OWENSOpenFASTWrappers.turbstruct[1].rootAcc[:, 1] ≈
+          Float32[0.0, 0.0, 0.7, 0.7, 0.0, 0.0] atol = 1f-6
 end


### PR DESCRIPTION
Adds pinned tests for OpenFAST wrapper inactive-guard/error-state paths, AeroDyn HAWT kinematics, deformAD15 state updates, and input-file quoting/writer branches.\n\nLocal verification:\n- julia --compiled-modules=no --project=. -e 'using Test; include("test/pure_helpers_unit.jl")'\n- julia --compiled-modules=no --project=. -e 'using Test; include("test/root_motion_unit.jl")'\n- julia --compiled-modules=no --code-coverage=user --project=. test/runtests.jl\n\nMerged src line coverage after run: 1162/1276 = 91.07%.