### PR TITLE
Expand OpenFAST wrapper documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,16 +1,24 @@
-using Documenter, Literate, OWENSOpenFASTWrappers
+using Documenter, OWENSOpenFASTWrappers
 
 # Build documentation
 makedocs(;
     modules = [OWENSOpenFASTWrappers],
+    build = get(ENV, "DOCUMENTER_BUILD_DIR", "build"),
     pages = [
         "Home" => "index.md",
-        "Quickstart" => "quickstart.md",
-        "OpenFAST Artifacts" => "openfast_artifacts.md",
-        "Wrapper Lifecycle" => "lifecycle.md",
-        "AeroDyn and InflowWind" => "aerodyn_inflowwind.md",
-        "HydroDyn and MoorDyn" => "hydrodyn_moordyn.md",
-        "Frames, Units, and Validation" => joinpath("theory", "frames_units_validation.md"),
+        "Getting Started" => [
+            "Quickstart" => "quickstart.md",
+            "OpenFAST Artifacts" => "openfast_artifacts.md",
+            "Wrapper Lifecycle" => "lifecycle.md",
+        ],
+        "Wrappers" => [
+            "AeroDyn and InflowWind" => "aerodyn_inflowwind.md",
+            "HydroDyn and MoorDyn" => "hydrodyn_moordyn.md",
+        ],
+        "Theory and Development" => [
+            "Frames, Units, and Validation" => joinpath("theory", "frames_units_validation.md"),
+            "Developer Guide" => "developer_guide.md",
+        ],
         "API Reference" => joinpath("reference", "reference.md"),
     ],
     sitename = "OWENSOpenFASTWrappers.jl",

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -1,0 +1,65 @@
+# Developer Guide
+
+This guide is for changes to wrappers, tests, examples, and documentation. The native calls are thin enough that small-looking edits can change physics behavior, memory layout, or cleanup state.
+
+## Before Editing
+
+Read the wrapper source and the corresponding test case together:
+
+| Source | Test or fixture |
+|:---|:---|
+| `src/inflowwind.jl` | `test/ifw_run.jl`, `test/data/ifw` |
+| `src/aerodyn.jl` | `test/aerodyn_run.jl`, `test/AeroDynInputs`, `test/HAWT_verification` |
+| `src/hydrodyn.jl` | `test/hydrodyn_run.jl`, `test/data/*HydroDyn.dat`, `test/data/*SeaState.dat`, `test/data/potflow` |
+| `src/moordyn.jl` | `test/moordyn_run.jl`, `test/data/moordyn_unit.h5` |
+
+Check the native OpenFAST function signature before changing a `ccall` argument type. The wrapper often converts Julia arrays to `Cfloat`, `Cdouble`, or `Cint` immediately at the call boundary.
+
+## Native State
+
+The wrappers keep library handles, native function symbols, error objects, and active flags in module globals. This keeps user calls simple, but it means wrapper changes must preserve cleanup behavior:
+
+1. Open the native library during initialization.
+2. Set the active flag only after the library and symbols are ready.
+3. Reset and check native error status after each call.
+4. On abort-level errors, end all active wrappers before throwing.
+5. Close the native library during the matching end function.
+
+When adding tests, prefer `try`/`finally` so cleanup runs even if a native module fails midway through a time loop.
+
+## Input Files and Generated Text
+
+The wrappers pass OpenFAST inputs either as file-path strings or as NUL-separated input text, depending on the module and function path. Keep this distinction explicit in docs and tests.
+
+Do not assume that relative paths inside OpenFAST files are resolved relative to the file itself. The native module may resolve them from the process working directory. Tests that rely on relative paths should set the working directory deliberately or use paths that are valid from the test process.
+
+Generated AeroDyn, OLAF, blade, and InflowWind files are useful for examples but are sensitive to OpenFAST input-format changes. For regression tests and physics comparisons, prefer reviewed fixture files checked into `test`.
+
+## Physics Review Checklist
+
+Before accepting a wrapper behavior change, check:
+
+| Topic | Questions |
+|:---|:---|
+| Units | Are time, length, speed, force, moment, density, gravity, and angular quantities still in the documented units? |
+| Frames | Did any `+X`, `+Y`, `+Z`, hub, blade, platform, or global-frame convention change? |
+| Signs | Do forces, moments, azimuth, roll, pitch, yaw, and rotor speed signs match the reference output? |
+| Ordering | Are mesh nodes, blade roots, struts, output channels, and six-DOF arrays in the native order expected by OpenFAST? |
+| State | Does the wrapper reinitialize when inputs, mesh topology, time step, or output channels change? |
+| Cleanup | Can the same test run twice in one Julia process without stale native state? |
+
+## Documentation
+
+Keep docs source in `docs/src`. Update `docs/make.jl` when adding or moving pages. The reference page uses Documenter autodocs, so public docstrings should stay accurate and concise.
+
+For source-level docstrings, document the unit, frame, mutation behavior, and cleanup expectation. Avoid documenting planned APIs as if they exist in the current checkout.
+
+## Local Build
+
+Build documentation from the package root with:
+
+```sh
+julia --project=OWENSOpenFASTWrappers.jl/docs OWENSOpenFASTWrappers.jl/docs/make.jl
+```
+
+If dependencies are already instantiated locally, this should not need network access. If a build tries to resolve missing packages, instantiate the docs environment outside a no-network workflow and rerun the build.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,27 +1,50 @@
 # OWENSOpenFASTWrappers.jl
 
-OWENSOpenFASTWrappers provides Julia lifecycle wrappers for selected OpenFAST libraries used by OWENS: InflowWind, AeroDyn, HydroDyn, and MoorDyn. It also exposes OpenFAST driver executables such as TurbSim through `OWENSOpenFAST_jll`.
+OWENSOpenFASTWrappers.jl provides Julia lifecycle wrappers around the OpenFAST
+libraries used by OWENS coupled simulations. The package currently covers
+InflowWind, AeroDyn plus InflowWind, HydroDyn, MoorDyn, and selected OpenFAST
+driver executables exposed by `OWENSOpenFAST_jll`.
 
 ![OWENSOpenFASTWrappers lifecycle](assets/openfast_lifecycle.svg)
 
-The package can be used standalone for focused OpenFAST-library calls or as the OpenFAST-facing backend for OWENS coupled simulations. Most wrappers follow the same pattern: initialize a library with input files and mesh/state data, call output and state-update functions at each time step, then end the instance to release global state.
+Use this package when a Julia workflow needs direct OpenFAST module calls
+instead of running a complete OpenFAST input deck. Each wrapped library owns
+native state, so the normal workflow is:
+
+1. Initialize the OpenFAST module with library paths, input files, mesh data,
+   and time settings.
+2. Pass motions or sample points into the module.
+3. Calculate outputs and, for dynamic modules, advance internal states.
+4. End the module before starting an independent case in the same Julia process.
 
 ## Wrapper Families
 
-| Family | Primary functions |
-| --- | --- |
-| InflowWind | `ifwinit`, `ifwcalcoutput`, `ifwend` |
-| AeroDyn | `adiInit`, `adiCalcOutput`, `adiUpdateStates`, `adiEnd`, plus the higher-level `setupTurb` path |
-| HydroDyn | `HD_Init`, `HD_CalcOutput`, `HD_UpdateStates`, `HD_End` |
-| MoorDyn | `MD_Init`, `MD_CalcOutput`, `MD_UpdateStates`, `MD_End` |
-| Driver binaries | `turbsim`, `aerodyn_driver`, `hydrodyn_driver`, `inflowwind_driver`, `moordyn_driver` |
+| Family | Main entry points | Typical role |
+|:---|:---|:---|
+| InflowWind | `ifwinit`, `ifwcalcoutput`, `ifwend`, `turbsim`, `inflowwind_driver` | Sample wind velocity at a point and time from generated InflowWind input or TurbSim data. |
+| AeroDyn/InflowWind | `setupTurb`, `deformAD15`, `advanceAD15`, `endTurb`; low-level `adi*` calls | Drive AeroDyn 15 with OWENS mesh motions and return distributed loads. |
+| HydroDyn | `HD_Init`, `HD_CalcOutput`, `HD_UpdateStates`, `HD_End`, `hydrodyn_driver` | Compute platform hydrodynamic loads from platform position, velocity, and acceleration. |
+| MoorDyn | `MD_Init`, `MD_CalcOutput`, `MD_UpdateStates`, `MD_End`, `moordyn_driver` | Compute mooring loads and output channels from platform motion. |
+| Driver executables | `turbsim`, `aerodyn_driver`, `hydrodyn_driver`, `inflowwind_driver`, `moordyn_driver` | Run OpenFAST module drivers supplied by the artifact package. |
 
 ## Documentation Map
 
-- [Quickstart](quickstart.md) covers installation and the smallest InflowWind-style lifecycle.
-- [OpenFAST Artifacts](openfast_artifacts.md) covers native-library resolution and platform smoke checks.
-- [Wrapper Lifecycle](lifecycle.md) explains init/calc/update/end ordering and global state cleanup.
-- [AeroDyn and InflowWind](aerodyn_inflowwind.md) records the aerodynamic wrapper path and input-file expectations.
-- [HydroDyn and MoorDyn](hydrodyn_moordyn.md) covers hydrodynamic and mooring wrappers.
-- [Frames, Units, and Validation](theory/frames_units_validation.md) lists unit/frame assumptions and test-hardening rules.
-- [API Reference](reference/reference.md) is the generated function and type index.
+Start with [Quickstart](@ref) for installation and the smallest test-style
+calls.
+
+Read [OpenFAST Artifacts](@ref) when the native libraries or driver executables
+are not found or cannot load.
+
+Read [Wrapper Lifecycle](@ref) before using multiple wrappers in a coupled time
+loop.
+
+Use [AeroDyn and InflowWind](@ref) and [HydroDyn and MoorDyn](@ref) for
+module-specific input and update patterns.
+
+Use [Frames, Units, and Validation](@ref) when checking signs, rotations, units,
+and comparison tolerances against OpenFAST output.
+
+Use [Developer Guide](@ref) before changing wrappers, tests, or documentation.
+
+Use [API Reference](@ref) for generated docstrings and exact exported call
+surfaces.

--- a/docs/src/reference/reference.md
+++ b/docs/src/reference/reference.md
@@ -1,14 +1,29 @@
+# API Reference
+
 ```@meta
 CurrentModule = OWENSOpenFASTWrappers
 ```
 
+This page is generated from docstrings in `OWENSOpenFASTWrappers`. Start with the guide pages for lifecycle and frame conventions, then use this page for exact call signatures and exported helper details.
+
+## Exported Groups
+
+| Group | Functions and types |
+|:---|:---|
+| InflowWind | `ifwinit`, `ifwcalcoutput`, `ifwend`, `turbsim`, `inflowwind_driver` |
+| AeroDyn/InflowWind | `Turbine`, `Environment`, `adiInit`, `adiCalcOutput`, `adiUpdateStates`, `adiEnd`, `aerodyn_driver` |
+| HydroDyn | `HD_Init`, `HD_CalcOutput`, `HD_UpdateStates`, `HD_End`, `hydrodyn_driver` |
+| MoorDyn | `MD_Init`, `MD_CalcOutput`, `MD_UpdateStates`, `MD_End`, `moordyn_driver` |
+
 ## Index
 
 ```@index
+Modules = [OWENSOpenFASTWrappers]
 ```
 
-## Types and functions
+## Types and Functions
 
 ```@autodocs
 Modules = [OWENSOpenFASTWrappers]
+Order = [:type, :function]
 ```


### PR DESCRIPTION
Summary:
- adds a developer guide covering native state, cleanup, input files, physics checks, and docs expectations
- groups Documenter navigation around getting started, wrappers, and theory/development pages
- expands home/reference docs to point users toward lifecycle, frame/unit, and module-specific guidance

Verification:
- julia --project=docs --startup-file=no --history-file=no -e 'ENV[DOCUMENTER_BUILD_DIR]=/private/tmp/owensopenfastwrappers_docs_build; include(docs/make.jl)' passed
- git diff --check --cached passed