### PR TITLE
Validate AeroDyn rotation before native init

### DIFF
--- a/src/aerodyn.jl
+++ b/src/aerodyn.jl
@@ -898,6 +898,8 @@ function setupTurb(adi_lib,ad_input_file,ifw_input_file,adi_rootname,bld_x,bld_z
     nacAngle    = [zeros(3) for i=1:numTurbines],                      # m
     )
 
+    validateADIRotationDirection(isHAWT, rotation_direction)
+
     if isnothing(adi_lib)
         # adi_lib = "$path/../deps/openfast/build/modules/aerodyn/libaerodyn_inflow_c_binding"
         adi_lib = libaerodyn_inflow_c_binding
@@ -914,7 +916,6 @@ function setupTurb(adi_lib,ad_input_file,ifw_input_file,adi_rootname,bld_x,bld_z
 
     global turbine = Array{Turbine}(undef, numTurbines)
     global turbstruct = Array{Structure}(undef, numTurbines)
-    validateADIRotationDirection(isHAWT, rotation_direction)
 
     for iturb = 1:numTurbines
 

--- a/test/pure_helpers_unit.jl
+++ b/test/pure_helpers_unit.jl
@@ -270,6 +270,33 @@ end
     @test aero_fatal[] isa ErrorException
     @test occursin("AeroDyn-Inflow terminated prematurely", sprint(showerror, aero_fatal[]))
 
+    missing_library = joinpath(tempdir(), "owens_openfast_missing_libaerodyn")
+    @test !isfile(missing_library)
+    minimal_aerodyn_setup_args = (
+        missing_library,
+        "AeroDyn.dat",
+        "InflowWind.dat",
+        "unit",
+        Any[],
+        Any[],
+        Int[],
+        0.0,
+        Any[],
+        Any[],
+        Any[],
+        Any[],
+    )
+    @test_throws ArgumentError OWENSOpenFASTWrappers.setupTurb(
+        minimal_aerodyn_setup_args...;
+        isHAWT=false,
+        rotation_direction=:cw,
+    )
+    @test_throws ArgumentError OWENSOpenFASTWrappers.setupTurb(
+        minimal_aerodyn_setup_args...;
+        isHAWT=true,
+        rotation_direction=:ccw,
+    )
+
     mktempdir() do dir
         hydro_file = joinpath(dir, "hydrodyn.dat")
         write(hydro_file, "header\nline\n")


### PR DESCRIPTION
## Summary
- validate AeroDyn rotation direction before resolving/loading the native library
- add pure-helper regression coverage so invalid rotation errors are not masked by missing native libraries

## Verification
- julia --project=. -e 'using Test; include("test/pure_helpers_unit.jl")'
- git diff --check origin/master..HEAD